### PR TITLE
Build against same source version as parent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ ENV CGO_ENABLED=0
 
 WORKDIR /go/src/app
 
-RUN go get -u github.com/kisielk/errcheck
-
 # explicitly install dependencies to improve Docker re-build times
 RUN go get -v \
+  github.com/kisielk/errcheck \
   github.com/hashicorp/terraform \
   github.com/pkg/errors \
   github.com/section-io/rackcorp-sdk-go/api \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN go get -v \
   golang.org/x/lint/golint \
   gopkg.in/h2non/gock.v1
 
+# Use specific version of terraform
+RUN cd /go/src/github.com/hashicorp/terraform && git fetch origin v0.11.1 --depth=1 && git reset --hard v0.11.1 
+
 RUN mkdir -p /go/src/github.com/section-io/ && \
   ln -s /go/src/app /go/src/github.com/section-io/terraform-provider-rackcorp
 

--- a/example.tf
+++ b/example.tf
@@ -26,7 +26,6 @@ resource "rackcorp_server" "example" {
   ]
   */
 
-
   /*
   firewall_policies = [
     {
@@ -43,15 +42,11 @@ resource "rackcorp_server" "example" {
   ]
   */
 
-
   // data_center_id = 19
-
 
   // name = "the-hostname-from-tf"
 
-
   // post_install_script = "${file("a-script.sh")}"
-
 
   // traffic_gb = 10
 


### PR DESCRIPTION
Previous builds have run into some strange behavior, and this may be related to state of fast-moving dependencies.
This is to lock down some of those dependencies, be more explicit about others, and repair state that was adjusted when previous builds required it.

Builds now show git version info. e.g.
```
Step 9/23 : RUN cd /go/src/github.com/section-io/terraform-provider-rac ... D) %'
 ---> Running in 85357a8dd18b
a42fdb08a43c7fabb8898fe8c286b793bbaa4835 /go/src/github.com/hashicorp/terraform
816c9085562cd7ee03e7f8188a1cfd942858cded /go/src/github.com/pkg/errors
8e61155a91672a880d5ee175389bb91b251e19e0 /go/src/github.com/section-io/rackcorp-sdk-go
 ---> 1b048aea58f1

```