### PR TITLE
Add location property to ProductDetails to provision in Melbourne

### DIFF
--- a/rackcorp/resourceRackcorpServer.go
+++ b/rackcorp/resourceRackcorpServer.go
@@ -252,6 +252,12 @@ func resourceRackcorpServer() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"dirty_config": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -286,6 +292,7 @@ func resourceRackcorpServerPopulateFromDevice(d *schema.ResourceData, config pro
 	panicOnError(d.Set("primary_ip", device.PrimaryIP))
 	panicOnError(d.Set("data_center_id", device.DataCenterId))
 	panicOnError(d.Set("firewall_policies", convertFirewallToMap(device.FirewallPolicies)))
+	panicOnError(d.Set("location", getExtraByKey("LOCATION", device.Extra)))
 
 	powerSwitch := getExtraByKey("SYS_POWERSWITCH", device.Extra)
 	if powerSwitch == "ONLINE" {
@@ -602,6 +609,10 @@ func resourceRackcorpServerCreate(d *schema.ResourceData, meta interface{}) erro
 		// Required due to omitempty int handling in json serialiser
 		productDetails.HostGroupID = new(int)
 		*productDetails.HostGroupID = hostGroupID.(int)
+	}
+
+	if location, ok := d.GetOk("location"); ok {
+		productDetails.Location = location.(string)
 	}
 
 	productCode := api.GetVirtualServerProductCode(

--- a/test-apply.sh
+++ b/test-apply.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+readonly SCRIPT_ROOT=$(pwd)
+terraform_image=gcr.io/section-io/terraform-provider-rackcorp:latest
+# ensure latest
+docker pull "${terraform_image}"
+
+terraform () {
+  docker run \
+    --rm \
+    -v "${SCRIPT_ROOT}/:/app/:rw" \
+    -e RACKCORP_API_UUID \
+    -e RACKCORP_API_SECRET \
+    -e RACKCORP_CUSTOMER_ID \
+    -w /app/ \
+    "${terraform_image}" \
+      "$@"
+}
+
+terraform fmt -diff -write=false
+
+terraform init -input=false
+
+terraform plan \
+  -out apply.tfplan
+
+if [ 'true' = "${SKIP_APPLY}" ]
+then
+  printf 'Skipping "terraform apply".\n'
+  exit
+fi
+
+terraform apply apply.tfplan
+

--- a/test-apply.sh
+++ b/test-apply.sh
@@ -8,9 +8,9 @@ terraform () {
   docker run \
     --rm \
     -v "${SCRIPT_ROOT}/:/app/:rw" \
-    -e RACKCORP_API_UUID \
-    -e RACKCORP_API_SECRET \
-    -e RACKCORP_CUSTOMER_ID \
+    -e RACKCORP_API_UUID="$RACKCORP_API_UUID" \
+    -e RACKCORP_API_SECRET="$RACKCORP_API_SECRET" \
+    -e RACKCORP_CUSTOMER_ID="$RACKCORP_CUSTOMER_ID" \
     -w /app/ \
     "${terraform_image}" \
       "$@"


### PR DESCRIPTION
1. using original provider and a example.tf without "location" and without "ignore", tf apply, ensure provisions in Sydney
2. using new provider and same *.tf, tf apply, ensure existing VM is untouched.
3. using new provider and add "location=MEL...", tf apply, ensure existing VM is deleted, replaced with VM in Melbourne
4. using new provider and set "location=SYD..." and "ignore_changes=location", tf apply, ensure existing VM is untouched.
5. using new provider and remove "ignore_changes",  tf apply, ensure Melbourne VM is deleted, replaced with VM in Sydney 